### PR TITLE
Fix #4

### DIFF
--- a/rob.cabal
+++ b/rob.cabal
@@ -28,20 +28,20 @@ library
                        Rob.Actions.List,
                        Rob.Actions.Add
   build-depends:       base >= 4.7 && < 5,
-                       fortytwo <= 1.0.2,
-                       directory <= 1.3.0.0,
-                       filepath <= 1.4.1.2,
-                       pathwalk <= 0.3.1.2,
-                       Glob <= 0.9.1,
-                       yaml <= 0.8.23.3,
-                       vector <= 0.12.0.1,
-                       ede == 0.2.8.7,
-                       text <= 1.2.2.2,
-                       unordered-containers <= 0.2.8.0,
-                       cmdargs >= 0.10.17 && <= 0.10.18,
-                       ansi-terminal <= 0.6.3.1,
-                       bytestring <= 0.10.8.1,
-                       time <= 1.6.0.1
+                       fortytwo, 
+                       directory, 
+                       filepath, 
+                       pathwalk, 
+                       Glob, 
+                       yaml,
+                       vector, 
+                       ede, 
+                       text, 
+                       unordered-containers, 
+                       cmdargs, 
+                       ansi-terminal,
+                       bytestring,
+                       time 
   other-modules:       Paths_rob
   default-language:    Haskell2010
 

--- a/rob.cabal
+++ b/rob.cabal
@@ -1,5 +1,5 @@
 name:                rob
-version:0.0.1
+version:             0.0.2.1
 synopsis:            Simple projects generator
 description:         See README at <https://github.com/GianlucaGuarini/rob/blob/develop/README.md>
 homepage:            https://github.com/gianlucaguarini/rob#readme
@@ -12,6 +12,8 @@ category:            CLI
 build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
+tested-with:         GHC == 8.4.4,
+                     GHC == 8.6.3
 
 library
   hs-source-dirs:      src


### PR DESCRIPTION
This removes (overly conservative) package bounds in the ``.cabal`` file to allow this to build on more recent GHCs, which is the cause of #4. I've also added the ``tested-with`` field in the ``.cabal`` file with the only GHC versions available to me. I don't know if some of the bounds are necessary for whatever reason, so feel free to request amendments.

Additionally, there was a deprecation warning as follows:

```
src/Rob/Config.hs:39:17: warning: [-Wdeprecations]
    In the use of ‘decodeFile’ (imported from Data.Yaml):
    Deprecated: "Please use decodeFileEither, which does not confused type-directed and runtime exceptions."
   |
39 |       config <- decodeFile path
   |                 ^^^^^^^^^^
```

By the sound of it, this merits investigation at least, but as I don't know the codebase well, I can't provide a fix.